### PR TITLE
Fixed XXE (XML External Entity)

### DIFF
--- a/mule-module-apikit/src/main/java/org/mule/module/apikit/validation/RestXmlSchemaValidator.java
+++ b/mule-module-apikit/src/main/java/org/mule/module/apikit/validation/RestXmlSchemaValidator.java
@@ -149,13 +149,7 @@ public class RestXmlSchemaValidator extends AbstractRestSchemaValidator
     {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         setFeatures(factory);
-        factory.setNamespaceAware(true);
-        factory.setXIncludeAware(false);
-        factory.setExpandEntityReferences(false);        
-        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false); 
+        factory.setNamespaceAware(true); 
         try
         {
             DocumentBuilder builder = factory.newDocumentBuilder();
@@ -184,8 +178,8 @@ public class RestXmlSchemaValidator extends AbstractRestSchemaValidator
         {
 
             // This is the PRIMARY defense. If DTDs (doctypes) are disallowed, almost all XML entity attacks are prevented
-            //feature  = "http://apache.org/xml/features/disallow-doctype-decl";
-            //dbf.setFeature(feature, true);
+            // feature  = "http://apache.org/xml/features/disallow-doctype-decl";
+            // dbf.setFeature(feature, true);
 
             // If you can't completely disable DTDs, then at least do the following:
             feature = "http://xml.org/sax/features/external-general-entities";
@@ -194,13 +188,15 @@ public class RestXmlSchemaValidator extends AbstractRestSchemaValidator
             feature = "http://xml.org/sax/features/external-parameter-entities";
             dbf.setFeature(feature, externalEntities);
 
+            feature = "http://apache.org/xml/features/nonvalidating/load-external-dtd";
+            dbf.setFeature(feature, externalEntities);
+
             feature = "http://apache.org/xml/features/disallow-doctype-decl";
             dbf.setFeature(feature, !expandEntities);
 
             // and these as well, per Timothy Morgan's 2014 paper: "XML Schema, DTD, and Entity Attacks" (see reference below)
             dbf.setXIncludeAware(expandEntities);
             dbf.setExpandEntityReferences(expandEntities);
-
         }
         catch (ParserConfigurationException e)
         {

--- a/mule-module-apikit/src/main/java/org/mule/module/apikit/validation/RestXmlSchemaValidator.java
+++ b/mule-module-apikit/src/main/java/org/mule/module/apikit/validation/RestXmlSchemaValidator.java
@@ -150,6 +150,12 @@ public class RestXmlSchemaValidator extends AbstractRestSchemaValidator
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         setFeatures(factory);
         factory.setNamespaceAware(true);
+        factory.setXIncludeAware(false);
+        factory.setExpandEntityReferences(false);        
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false); 
         try
         {
             DocumentBuilder builder = factory.newDocumentBuilder();


### PR DESCRIPTION
:gear: **Fix:**

This is a really interesting vulnerability especially because it's on a Java XML Parser. It started a long ago that security researchers started poking with different kinds of Java XML Parsers like `DocumentBuilderFactory`, `TransformerFactory`, `SAXParserFactory` etc for XXEs (`XML External Entity`).

The fix is however usually mitigated by the following snippet:
```java
DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
```

But it turns out `FEATURE_SECURE_PROCESSING` alone seems not to be secure enough.

:spiral_notepad: **Source:** [Black Hat Paper on XXEs in Java Parsers](https://www.blackhat.com/docs/us-15/materials/us-15-Wang-FileCry-The-New-Age-Of-XXE-java-wp.pdf)

[OWASP](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#TransformerFactory) recommends `ACCESS_EXTERNAL_DTD` and `ACCESS_EXTERNAL_STYLESHEET` but it's mainly centered for the `TransformerFactory` Parser. As it's implemented in `DocumentBuilderFactory` and has been used in other functions as well, I wrote a fix for it rather than switching to any other parsers.

Thanks to [this gist](https://gist.github.com/AlainODea/1779a7c6a26a5c135280bc9b3b71868f). :raised_hands: 

:books: **Reference:**
- https://stackoverflow.com/questions/40649152/how-to-prevent-xxe-attack
- https://gist.github.com/AlainODea/1779a7c6a26a5c135280bc9b3b71868f
- https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html
- https://www.blackhat.com/docs/us-15/materials/us-15-Wang-FileCry-The-New-Age-Of-XXE-java-wp.pdf
- https://stackoverflow.com/questions/30710966/how-do-i-globally-configure-xml-parsers-against-xxe
- https://dev.to/brianverm/configure-your-java-xml-parsers-to-prevent-xxe-213c

<hr>

### :v: **Fixed!**

<hr>